### PR TITLE
use global funding eligibility object

### DIFF
--- a/__sdk__.js
+++ b/__sdk__.js
@@ -5,9 +5,8 @@ const globals = require('./globals');
 
 module.exports = {
     common: {
-        automatic:       true,
-        entry:           './src/interface',
-        staticNamespace: '__paypal_common__',
+        automatic: true,
+        entry:     './src/interface',
         globals
     }
 };

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "jsx-pragmatic": "^2",
     "post-robot": "^10.0.0",
     "zalgo-promise": "^1.0.10",
-    "zoid": "^9.0.0"
+    "zoid": "^9.0.82"
   }
 }

--- a/src/declarations.js
+++ b/src/declarations.js
@@ -1,17 +1,9 @@
 /* @flow */
 /* eslint import/unambiguous: 0 */
 
-import type { FundingEligibilityType } from '@paypal/sdk-client/src';
 import { FUNDING } from '@paypal/sdk-constants/src';
 
 declare var __PAYPAL_CHECKOUT__ : {|
     __REMEMBERED_FUNDING__ : Array<$Values<typeof FUNDING>> // eslint-disable-line flowtype/no-mutable-array
 |};
 
-declare var __paypal_checkout__ : {|
-    serverConfig : {|
-        fundingEligibility : FundingEligibilityType
-    |}
-|};
-
-declare var __hosted_fields__ : void;

--- a/src/globals.js
+++ b/src/globals.js
@@ -1,11 +1,6 @@
 /* @flow */
 
-import type { FundingEligibilityType } from '@paypal/sdk-client/src';
 import { FUNDING } from '@paypal/sdk-constants/src';
-
-export function getFundingEligibility() : FundingEligibilityType {
-    return __paypal_checkout__.serverConfig.fundingEligibility;
-}
 
 export function getRememberedFunding() : Array<$Values<typeof FUNDING>> { // eslint-disable-line flowtype/no-mutable-array
     return __PAYPAL_CHECKOUT__.__REMEMBERED_FUNDING__;


### PR DESCRIPTION
## Disclaimer
The following is what I believe to be true but I would love for someone with more knowledge of the past to come fill in the gaps or point out anything I got wrong.


## Summary
I'm removing two parts of this repo that I don't think are used any longer by either this package or any other sdk packages. The first part is `getFundingEligibility` which seems to be a dead function. The second part is removing the `staticNamespace` from `__sdk__.js`. The existence of a `staticNamepace` causes `clientsdknodeweb` to inject an extra global into its cacheKey and into the sdk itself.


## Removing `getFundingEligibility`
In the past, components would be responsible for fetching their own funding eligibility status, or at least they would be supplied their own version of it from `clientsdknodeweb` and not share this information with other components. At some point near the creation of [this commit](https://github.com/paypal/paypal-checkout-components/commit/a518d85fc0e2ebcc495e6c0bf50ae4572e6eec1e) that all changed. We added a `__FUNDING_ELIGIBILITY__` property to the global object that webpack injects when building the sdk. `@paypal/checkout-components` was converted to us `__FUNDING_ELIGIBILTIY__` instead of its static namespace `__paypal_checkout__.serverConfig.fundingEligibility`

[This commit](https://github.com/paypal/paypal-sdk-client/commit/0fc5d553aa85d0c5e60d94ca3ef4bcd661e2264a) in `@paypal/sdk-client` added a `getFundingEligibility` which is how most of the components now ask for funding eligibility. Its a simple function:
```
export function getFundingEligibility() : FundingEligibilityType {
    return __FUNDING_ELIGIBILITY__;
}
```
Most components (with a few exceptions that I'll explain below) import this function from `@paypal/sdk-client` and use `getFundingEligibility` when they need funding eligibility info.

You can see that this package also defines a `getFundingEligibility` function. I've done a lot of searching though, through all the repos we define as [being in the sdk](https://uideploy--staticcontent--a707ae8c07c3f--ghe.preview.dev.paypalinc.com/js-sdk-release/paypal/sdk-release/info.json) and I haven't found any that rely on `getFundingEligibility` from this package. This package doesn't even use `getFundingEligibility` or any other funding eligibility information. 


## Removing `staticNamespace`
The `__sdk__.js` files are used to define meta information for each component. `clientsdknodeweb` and `smartcomponentnodeweb` both use this to make their `alias` function work. `clientsdknodeweb` goes further with this information though. This component meta info is used to bundle the right components for the sdk. Its also being used to pass down `fundingEligibility` to a component namespace like this:
```
/* clientsdknodeweb/server/sdk/globals.js */

if (staticNamespace) {
    buildGlobals[staticNamespace] = {
        serverConfig: {
            fundingEligibility
        }
    };
}
```
That's how this repo can then use `__paypal_common__.serverConfig.fundingEligibility`

The thing is, based on the Removing `getFundingEligibility` section above, I don't think any of that is needed any longer. This package doesn't rely on any funding eligibility info and the function that it exports isn't used by any packages either.

You can also see that this package isn't even using it's own staticNamespace. It defines its staticNamespace as `__paypal_common__` but is using `__paypal_checkout__` which doesn't exist any longer because of [this commit](https://github.com/paypal/paypal-checkout-components/commit/a518d85fc0e2ebcc495e6c0bf50ae4572e6eec1e).

Removing `staticNamespace` from this package will remove a copy of the the funding eligibility response from being used in the cache key that `clientsdknodeweb` uses to serve sdk files. It will also clean up the the globals namespace by removing unused values.

## What Comes Next
[`@paypal/muse-components`](https://github.com/paypal/paypal-muse-components) and [`@paypal/card-components`](https://github.com/paypal/paypal-card-components) are the only other packages that define a `staticNamespace`. `@paypal/muse-components` is like this package in that it doesn't use it's personal funding eligibility response so we can safely remove it. `@paypal/card-components` needs to be converted to using the `getFundingEligibility` from `@paypal/sdk-client` and tested to make sure nothing breaks.

After that, we can update `clientsdknodeweb` to ignore `staticNamespace` entirely.