### PR TITLE
Test with zoid 9.0.81

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ Common components for the PayPal JavaScript SDK
 
 Please feel free to follow the [Contribution Guidelines](./CONTRIBUTING.md) to contribute to this repository. PRs are welcome, but for major changes please raise an issue first.
 
-Test
-
 ### Quick Setup
 
 Set up your env:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Common components for the PayPal JavaScript SDK
 
 Please feel free to follow the [Contribution Guidelines](./CONTRIBUTING.md) to contribute to this repository. PRs are welcome, but for major changes please raise an issue first.
 
+Test
+
 ### Quick Setup
 
 Set up your env:

--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -12,7 +12,7 @@ import { Overlay } from '../overlay';
 import { getThreeDomainSecureUrl } from '../config';
 
 export type TDSResult = {|
-    
+
 |};
 
 export const USER_TYPE = {
@@ -102,7 +102,7 @@ export function getThreeDomainSecureComponent() : TDSComponent {
                                 return onError(err);
                             }
 
-                            return value(true);
+                            return value(err, result);
                         };
                     }
                 },


### PR DESCRIPTION
Updating the use of `decorate` to work with zoid 9.0.81.