### PR TITLE
fix: add boletobancario

### DIFF
--- a/test/globals.js
+++ b/test/globals.js
@@ -77,6 +77,9 @@ export const fundingEligibility = {
     boleto: {
         eligible: false
     },
+    boletobancario: {
+        eligible: false
+    },
     multibanco: {
         eligible: false
     }

--- a/test/integration/globals.js
+++ b/test/integration/globals.js
@@ -77,6 +77,9 @@ window.__TEST_FUNDING_ELIGIBILITY__ = {
     boleto: {
         eligible: false
     },
+    boletobancario: {
+        eligible: false
+    },
     multibanco: {
         eligible: false
     }


### PR DESCRIPTION
Changed `boleto` to `boletobancario`

https://engineering.paypalcorp.com/jira/browse/DTALTPAY-919
Naming convention for Boleto / Boletobancario changed to match that of the confirm-payment-source call (boletobancario).