### PR TITLE
Adding mercadopago back

### DIFF
--- a/test/globals.js
+++ b/test/globals.js
@@ -65,15 +65,6 @@ export const fundingEligibility = {
   wechatpay: {
     eligible: false,
   },
-  zimpler: {
-    eligible: false,
-  },
-  mercadopago: {
-    eligible: false,
-  },
-  verkkopankki: {
-    eligible: false,
-  },
   boleto: {
     eligible: false,
   },

--- a/test/globals.js
+++ b/test/globals.js
@@ -65,6 +65,9 @@ export const fundingEligibility = {
   wechatpay: {
     eligible: false,
   },
+  mercadopago: {
+    eligible: false,
+  },
   boleto: {
     eligible: false,
   },

--- a/test/integration/globals.js
+++ b/test/integration/globals.js
@@ -65,6 +65,9 @@ window.__TEST_FUNDING_ELIGIBILITY__ = {
   wechatpay: {
     eligible: false,
   },
+  mercadopago: {
+    eligible: false,
+  },
   boleto: {
     eligible: false,
   },

--- a/test/integration/globals.js
+++ b/test/integration/globals.js
@@ -65,15 +65,6 @@ window.__TEST_FUNDING_ELIGIBILITY__ = {
   wechatpay: {
     eligible: false,
   },
-  zimpler: {
-    eligible: false,
-  },
-  mercadopago: {
-    eligible: false,
-  },
-  verkkopankki: {
-    eligible: false,
-  },
   boleto: {
     eligible: false,
   },


### PR DESCRIPTION
we have mercadopago being used by merchants still to call disable and enable funding calls in js sdk request. Once all merchants have stopped their integration we will go back to remove this
https://paypal.atlassian.net/browse/DTALTPAY-1347