### PR TITLE
chore: update 3ds onSuccess callback signature

### DIFF
--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -109,7 +109,7 @@ export function getThreeDomainSecureComponent(): TDSComponent {
                 return onError(err);
               }
 
-              return value(true, result);
+              return value(result);
             };
           },
         },

--- a/test/integration/tests/three-domain-secure/happy.js
+++ b/test/integration/tests/three-domain-secure/happy.js
@@ -50,7 +50,7 @@ describe(`paypal 3ds component happy path`, () => {
       return window.paypal
         .ThreeDomainSecure({
           createOrder: () => "XXXXXXXXXXXXXXXXX",
-          onSuccess: expect("onSuccess", (_err, result) => {
+          onSuccess: expect("onSuccess", (result) => {
             if (!result.liability_shift) {
               throw new Error("missing liability_shift in result");
             }


### PR DESCRIPTION
This PR changes the 3ds `onSuccess()` callback from `onSuccess(boolean, object)` to `onSuccess(object)`. The `onError()` callback should be used for detecting an error from the 3DS flow. 