### PR TITLE
use value from prop and set verify as default 3ds action

### DIFF
--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -77,7 +77,7 @@ export function getThreeDomainSecureComponent(): TDSComponent {
         action: {
           type: "string",
           queryParam: true,
-          value: () => "verify",
+          value: (data) => (data.props.action ? data.props.action : "verify"),
         },
         xcomponent: {
           type: "string",

--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -94,6 +94,13 @@ export function getThreeDomainSecureComponent(): TDSComponent {
           queryParam: "cart_id",
           // $FlowFixMe[incompatible-call]
           queryValue: ({ value }) => ZalgoPromise.try(value),
+          required: false,
+        },
+        vaultToken: {
+          type: "string",
+          queryParam: "token",
+          queryValue: ({ value }) => value,
+          required: false,
         },
         clientID: {
           type: "string",

--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -99,6 +99,9 @@ export function getThreeDomainSecureComponent(): TDSComponent {
         vaultToken: {
           type: "string",
           queryParam: "token",
+          // We do not need to add queryValue here.
+          // This code has gone through E2E approval and so we are keeping it as a safeguard
+          // Refer zoid documentation for further clarity.
           queryValue: ({ value }) => value,
           required: false,
         },

--- a/test/integration/tests/three-domain-secure/happy.js
+++ b/test/integration/tests/three-domain-secure/happy.js
@@ -19,6 +19,21 @@ describe(`paypal 3ds component happy path`, () => {
     });
   });
 
+  it("should render the 3ds component with vaultToken", () => {
+    return wrapPromise(({ expect, avoid }) => {
+      const vaultToken = "abc123";
+      return window.paypal
+        .ThreeDomainSecure({
+          createOrder: () => "XXXXXXXXXXXXXXXXX",
+          onSuccess: expect("onSuccess"),
+          onCancel: avoid("onCancel"),
+          onError: avoid("onError"),
+          vaultToken,
+        })
+        .render("body");
+    });
+  });
+
   it("should not render the 3ds component", () => {
     return wrapPromise(({ expect, avoid }) => {
       const nonce = "12345";


### PR DESCRIPTION
#### Description
- For Helios redirect to work with Vault without purchase flow, the action needs to be `authenticate` and the default `verify` would not work. 
- In order to enable that, we are sending this value as prop when we call ThreeDomainSecure for the new Hosted Card fields integration.
- If action isn't available in props, we default this value to `verify` for backward compatibility.
- `createOrder` will not be present for without purchase cases and so we need to make it optional.
- `vaultToken` returns the token to be consumed by helios for the authentication flow. This `token` is returned along with the contingency and the redirect url.

**JIRA: DTNOR-1005**
#### Components to test
- [ ] Legacy HCF
- [ ] New HCF 
    - [ ] Vault with purchase
    - [ ] Vault without purchase
    - [ ] With Purchase
- [ ] BCDC Button
- [ ] ?


