### PR TITLE
fix alerts as they break async flows

### DIFF
--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -3,8 +3,6 @@
 /* eslint max-lines: off, react/jsx-max-depth: off */
 
 import {
-  isIos,
-  isFirefox,
   animate,
   noop,
   destroyElement,

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -66,11 +66,11 @@ export function Overlay({
       return;
     }
 
+    // Note: alerts block the event loop until they are closed.
     if (isIos()) {
       // eslint-disable-next-line no-alert
       window.alert("Please switch tabs to reactivate the PayPal window");
     } else if (isFirefox()) {
-      //
       // eslint-disable-next-line no-alert
       window.alert(
         'Don\'t see the popup window after clicking "OK"?\n\nSelect "Window" in your toolbar to find "Log in to your PayPal account"'

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -3,6 +3,8 @@
 /* eslint max-lines: off, react/jsx-max-depth: off */
 
 import {
+  isIos,
+  isFirefox,
   animate,
   noop,
   destroyElement,
@@ -64,6 +66,16 @@ export function Overlay({
       return;
     }
 
+    if (isIos()) {
+      // eslint-disable-next-line no-alert
+      window.alert("Please switch tabs to reactivate the PayPal window");
+    } else if (isFirefox()) {
+      //
+      // eslint-disable-next-line no-alert
+      window.alert(
+        'Don\'t see the popup window after clicking "OK"?\n\nSelect "Window" in your toolbar to find "Log in to your PayPal account"'
+      );
+    }
     focus();
   }
 
@@ -166,7 +178,10 @@ export function Overlay({
                   )}
                   {content.continueMessage && (
                     <div class="paypal-checkout-continue">
-                      <a onClick={focus} href="#">
+                      {/* This handler should be guarded with e.stopPropagation. 
+                          This will stop the event from bubbling up to the overlay click handler
+                          and causing unexpected behavior. */}
+                      <a onClick={focusCheckout} href="#">
                         {content.continueMessage}
                       </a>
                     </div>

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -66,17 +66,7 @@ export function Overlay({
       return;
     }
 
-    if (isIos()) {
-      // eslint-disable-next-line no-alert
-      window.alert("Please switch tabs to reactivate the PayPal window");
-    } else if (isFirefox()) {
-      // eslint-disable-next-line no-alert
-      window.alert(
-        'Don\'t see the popup window?\n\nSelect "Window" in your toolbar to find "Log in to your PayPal account"'
-      );
-    } else {
-      focus();
-    }
+    focus();
   }
 
   const setupAnimations = (name) => {


### PR DESCRIPTION
LI-25798:
`focusCheckout` was being called after `focus` because of the click event propagation. This was causing the popup to focus and then the alert to show (which was blocking async operations). The suggested fix is to stop propagation on link click and show alerts before focusing. This way we keep alerts for users and we ensure focus happens after closing the alert.