### PR TITLE
Venmo overlay

### DIFF
--- a/src/overlay/style.js
+++ b/src/overlay/style.js
@@ -462,11 +462,6 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
             color: #fff;
         }
 
-        #${uid} .venmo-checkout-close:before,
-        #${uid} .venmo-checkout-close:after {
-            background-color: #fff;
-        }
-
         #${uid}.venmo-overlay-context-${CONTEXT.POPUP} {
             cursor: pointer;
         }
@@ -476,18 +471,24 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
         }
 
         #${uid} .venmo-checkout-modal {
-            font-family: "HelveticaNeue", "HelveticaNeue-Light", "Helvetica Neue Light", helvetica, arial, sans-serif;
-            font-size: 14px;
-            text-align: center;
-
             box-sizing: border-box;
-            max-width: 350px;
+            max-width: 400px;
             top: 50%;
             left: 50%;
             position: absolute;
             transform: translateX(-50%) translateY(-50%);
             cursor: pointer;
             text-align: center;
+        }
+
+        #${uid} .venmo-checkout-modal .venmo-interrogative-message {
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            font-style: normal;
+            font-size: 24px;
+            line-height: 32px;
+            text-align: center;
+            color: #FFFFFF;
+            margin-top: 32px;
         }
 
         #${uid}.venmo-overlay-loading .venmo-checkout-message, #${uid}.venmo-overlay-loading .venmo-checkout-continue {
@@ -504,12 +505,10 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
 
         #${uid} .venmo-checkout-modal .venmo-checkout-logo {
             cursor: pointer;
-            margin-bottom: 30px;
-            display: inline-block;
         }
 
         #${uid} .venmo-checkout-modal .venmo-checkout-logo img {
-            height: 36px;
+            height: 46px;
         }
 
         #${uid} .venmo-checkout-modal .venmo-checkout-logo img.venmo-checkout-logo-pp {
@@ -517,9 +516,15 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
         }
 
         #${uid} .venmo-checkout-modal .venmo-checkout-message {
-            font-size: 15px;
-            line-height: 1.5;
-            padding: 10px 0;
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            font-style: normal;
+            font-weight: 400;
+            font-size: 16px;
+            line-height: 20px;
+            text-align: center;
+            color: #FFFFFF;
+            margin-top: 16px;
+            width: 400px;
         }
 
         #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-message, #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-continue {
@@ -527,47 +532,40 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
         }
 
         #${uid} .venmo-checkout-modal .venmo-checkout-continue {
-            font-size: 15px;
-            line-height: 1.35;
-            padding: 10px 0;
-            font-weight: bold;
+            width: 400px;
+            height: 50px;
+            background: #0074DE;
+            border-radius: 24px;
+            border: none;
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            font-style: normal;
+            font-weight: 700;
+            font-size: 18px;
+            color: #FFFFFF;
+            margin-top: 44px;
         }
 
         #${uid} .venmo-checkout-modal .venmo-checkout-continue a {
-            border-bottom: 1px solid white;
+            line-height: 50px;
         }
 
         #${uid} .venmo-checkout-close {
-            position: absolute;
-            right: 16px;
-            top: 16px;
-            width: 16px;
-            height: 16px;
-            opacity: 0.6;
+            height: 24px;
+            width: 400px;
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            font-style: normal;
+            font-weight: 700;
+            font-size: 18px;
+            line-height: 24px;
+            text-align: center;
+            background-color: transparent;
+            border: none;
+            color: #FFFFFF;
+            margin-top: 28px;
         }
 
         #${uid}.venmo-overlay-loading .venmo-checkout-close {
             display: none;
-        }
-
-        #${uid} .venmo-checkout-close:hover {
-            opacity: 1;
-        }
-
-        #${uid} .venmo-checkout-close:before, .venmo-checkout-close:after {
-            position: absolute;
-            left: 8px;
-            content: ' ';
-            height: 16px;
-            width: 2px;
-        }
-
-        #${uid} .venmo-checkout-close:before {
-            transform: rotate(45deg);
-        }
-
-        #${uid} .venmo-checkout-close:after {
-            transform: rotate(-45deg);
         }
 
         #${uid} .venmo-checkout-iframe-container {

--- a/src/overlay/style.js
+++ b/src/overlay/style.js
@@ -473,6 +473,8 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
         #${uid} .venmo-checkout-modal {
             box-sizing: border-box;
             max-width: 400px;
+            min-width: 300px;
+            max-height: 100%;
             top: 50%;
             left: 50%;
             position: absolute;
@@ -511,10 +513,6 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
             height: 46px;
         }
 
-        #${uid} .venmo-checkout-modal .venmo-checkout-logo img.venmo-checkout-logo-pp {
-            margin-right: 10px;
-        }
-
         #${uid} .venmo-checkout-modal .venmo-checkout-message {
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
             font-style: normal;
@@ -524,7 +522,6 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
             text-align: center;
             color: #FFFFFF;
             margin-top: 16px;
-            width: 400px;
         }
 
         #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-message, #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-continue {
@@ -532,8 +529,6 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
         }
 
         #${uid} .venmo-checkout-modal .venmo-checkout-continue {
-            width: 400px;
-            height: 50px;
             background: #0074DE;
             border-radius: 24px;
             border: none;
@@ -550,8 +545,6 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
         }
 
         #${uid} .venmo-checkout-close {
-            height: 24px;
-            width: 400px;
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
             font-style: normal;
             font-weight: 700;

--- a/src/overlay/style.js
+++ b/src/overlay/style.js
@@ -372,3 +372,366 @@ export function getContainerStyle({ uid }: {| uid: string |}): string {
         }
     `;
 }
+
+export function getVenmoSandboxStyle({ uid }: {| uid: string |}): string {
+  return `
+        #${uid}.venmo-checkout-sandbox {
+            display: block;
+            position: fixed;
+            top: 0;
+            left: 0;
+
+            width: 100%;
+            height: 100%;
+            width: 100vw;
+            height: 100vh;
+            max-width: 100%;
+            max-height: 100%;
+            min-width: 100%;
+            min-height: 100%;
+
+            z-index: 2147483647;
+
+            animation-duration: 0.3s;
+            animation-iteration-count: 1;
+            animation-fill-mode: forwards !important;
+            opacity: 0;
+        }
+
+        #${uid}.venmo-checkout-sandbox .venmo-checkout-sandbox-iframe {
+            display: block;
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+        }
+
+        #${uid}.venmo-checkout-sandbox .venmo-checkout-sandbox-iframe-full {
+            border: 0;
+            height: 100%;
+            width: 100vw;
+        }
+
+        @keyframes show-container {
+            from {
+                opacity: 0;
+            }
+
+            to {
+                opacity: 1;
+            }
+        }
+
+        @keyframes hide-container {
+            from {
+                opacity: 1;
+            }
+
+            50% {
+                opacity: 1;
+            }
+
+            to {
+                opacity: 0;
+            }
+        }
+    `;
+}
+
+export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
+  return `
+        #${uid} {
+            position: absolute;
+            z-index: 2147483647;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+
+            transform: translate3d(0, 0, 0);
+
+            background-color: black;
+            background-color: rgba(0, 0, 0, 0.4);
+            background: radial-gradient(50% 50%, ellipse closest-corner, rgba(0,0,0,0.6) 1%, rgba(0,0,0,0.8) 100%);
+
+            color: #fff;
+        }
+
+        #${uid} a {
+            color: #fff;
+        }
+
+        #${uid} .venmo-checkout-close:before,
+        #${uid} .venmo-checkout-close:after {
+            background-color: #fff;
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.POPUP} {
+            cursor: pointer;
+        }
+
+        #${uid} a {
+            text-decoration: none;
+        }
+
+        #${uid} .venmo-checkout-modal {
+            font-family: "HelveticaNeue", "HelveticaNeue-Light", "Helvetica Neue Light", helvetica, arial, sans-serif;
+            font-size: 14px;
+            text-align: center;
+
+            box-sizing: border-box;
+            max-width: 350px;
+            top: 50%;
+            left: 50%;
+            position: absolute;
+            transform: translateX(-50%) translateY(-50%);
+            cursor: pointer;
+            text-align: center;
+        }
+
+        #${uid}.venmo-overlay-loading .venmo-checkout-message, #${uid}.venmo-overlay-loading .venmo-checkout-continue {
+            display: none;
+        }
+
+        .venmo-checkout-loader {
+            display: none;
+        }
+
+        #${uid}.venmo-overlay-loading .venmo-checkout-loader {
+            display: block;
+        }
+
+        #${uid} .venmo-checkout-modal .venmo-checkout-logo {
+            cursor: pointer;
+            margin-bottom: 30px;
+            display: inline-block;
+        }
+
+        #${uid} .venmo-checkout-modal .venmo-checkout-logo img {
+            height: 36px;
+        }
+
+        #${uid} .venmo-checkout-modal .venmo-checkout-logo img.venmo-checkout-logo-pp {
+            margin-right: 10px;
+        }
+
+        #${uid} .venmo-checkout-modal .venmo-checkout-message {
+            font-size: 15px;
+            line-height: 1.5;
+            padding: 10px 0;
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-message, #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-continue {
+            display: none;
+        }
+
+        #${uid} .venmo-checkout-modal .venmo-checkout-continue {
+            font-size: 15px;
+            line-height: 1.35;
+            padding: 10px 0;
+            font-weight: bold;
+        }
+
+        #${uid} .venmo-checkout-modal .venmo-checkout-continue a {
+            border-bottom: 1px solid white;
+        }
+
+        #${uid} .venmo-checkout-close {
+            position: absolute;
+            right: 16px;
+            top: 16px;
+            width: 16px;
+            height: 16px;
+            opacity: 0.6;
+        }
+
+        #${uid}.venmo-overlay-loading .venmo-checkout-close {
+            display: none;
+        }
+
+        #${uid} .venmo-checkout-close:hover {
+            opacity: 1;
+        }
+
+        #${uid} .venmo-checkout-close:before, .venmo-checkout-close:after {
+            position: absolute;
+            left: 8px;
+            content: ' ';
+            height: 16px;
+            width: 2px;
+        }
+
+        #${uid} .venmo-checkout-close:before {
+            transform: rotate(45deg);
+        }
+
+        #${uid} .venmo-checkout-close:after {
+            transform: rotate(-45deg);
+        }
+
+        #${uid} .venmo-checkout-iframe-container {
+            display: none;
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container,
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container > .${CLASS.OUTLET},
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container > .${CLASS.OUTLET} > iframe {
+            max-height: 95vh;
+            max-width: 95vw;
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container-full,
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container-full > .${CLASS.OUTLET},
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container-full > .${CLASS.OUTLET} > iframe {
+            height: 100vh;
+            max-width: 100vw;
+            width: 100vw;
+        }
+
+        @media screen and (max-width: 470px) {
+            #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container,
+            #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container > .${CLASS.OUTLET},
+            #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container > .${CLASS.OUTLET} > iframe {
+                max-height: 85vh;
+            }
+            #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container-full,
+            #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container-full > .${CLASS.OUTLET},
+            #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container-full > .${CLASS.OUTLET} > iframe {
+                height: 100vh;
+            }
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container {
+
+            display: block;
+
+            position: absolute;
+
+            top: 50%;
+            left: 50%;
+
+            min-width: 450px;
+
+            transform: translate(-50%, -50%);
+            transform: translate3d(-50%, -50%, 0);
+
+            border-radius: 10px;
+            overflow: hidden;
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .${CLASS.OUTLET} {
+
+            position: relative;
+
+            transition: all 0.3s ease;
+            animation-duration: 0.3s;
+            animation-fill-mode: forwards !important;
+
+            min-width: 450px;
+            max-width: 450px;
+            width: 450px;
+            height: 535px;
+
+            background-color: white;
+
+            overflow: auto;
+
+            opacity: 0;
+            transform: scale3d(.3, .3, .3);
+
+            -webkit-overflow-scrolling: touch;
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .${CLASS.OUTLET} > iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            transition: opacity .4s ease-in-out;
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .${CLASS.OUTLET} > iframe.${CLASS.COMPONENT_FRAME} {
+            z-index: 100;
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .${CLASS.OUTLET} > iframe.${CLASS.PRERENDER_FRAME} {
+            z-index: 200;
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .${CLASS.OUTLET} > iframe.${CLASS.VISIBLE} {
+            opacity: 1;
+            z-index: 200;
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .${CLASS.OUTLET} > iframe.${CLASS.INVISIBLE} {
+            opacity: 0;
+            z-index: 100;
+        }
+
+        @media screen and (max-width: 470px) {
+
+            #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .venmo-checkout-iframe-container,
+            #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .${CLASS.OUTLET} {
+                min-width: 100%;
+                min-width: calc(100% - 20px);
+
+                max-width: 100%;
+                max-width: calc(100% - 20px);
+            }
+        }
+
+        #${uid}.venmo-overlay-context-${CONTEXT.IFRAME} .${CLASS.OUTLET} iframe {
+            width: 1px;
+            min-width: 100%;
+            height: 100%;
+        }
+
+        @keyframes show-component {
+            from {
+                opacity: 0;
+                transform: scale3d(.3, .3, .3);
+            }
+
+            to {
+                opacity: 1;
+                transform: scale3d(1, 1, 1);
+            }
+        }
+
+        @keyframes hide-component {
+            from {
+                opacity: 1;
+                transform: scale3d(1, 1, 1);
+            }
+
+            to {
+                opacity: 0;
+                transform: scale3d(.3, .3, .3);
+            }
+        }
+
+        .venmo-spinner {
+            height: 30px;
+            width: 30px;
+            display: inline-block;
+            box-sizing: content-box;
+            opacity: 1;
+            filter: alpha(opacity=100);
+            animation: rotation .7s infinite linear;
+            border-left: 8px solid rgba(0, 0, 0, .2);
+            border-right: 8px solid rgba(0, 0, 0, .2);
+            border-bottom: 8px solid rgba(0, 0, 0, .2);
+            border-top: 8px solid #fff;
+            border-radius: 100%
+        }
+
+        @keyframes rotation {
+            from {
+                transform: rotate(0deg)
+            }
+            to {
+                transform: rotate(359deg)
+            }
+        }
+    `;
+}

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -361,7 +361,7 @@ export function VenmoOverlay({
                       </a>
                     </div>
                   )}
-                  {content.cancelMessage && (
+                  {content.cancelMessage && !hideCloseButton && (
                     <div class="venmo-checkout-close">
                       <a href="#" onClick={closeCheckout} aria-label="close">
                         {content.cancelMessage}

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -42,6 +42,7 @@ export type OverlayProps = {|
     windowMessage?: string,
     continueMessage?: string,
     cancelMessage?: string,
+    interrogativeMessage?: string,
   |},
   autoResize?: boolean,
   hideCloseButton?: boolean,
@@ -343,6 +344,11 @@ export function VenmoOverlay({
                   <div class="venmo-checkout-logo">
                     <VenmoLogo logoColor={LOGO_COLOR.WHITE} />
                   </div>
+                  {content.interrogativeMessage && (
+                    <div class="venmo-interrogative-message">
+                      {content.interrogativeMessage}
+                    </div>
+                  )}
                   {content.windowMessage && (
                     <div class="venmo-checkout-message">
                       {content.windowMessage}
@@ -356,7 +362,7 @@ export function VenmoOverlay({
                     </div>
                   )}
                   {content.cancelMessage && (
-                    <div class="venmo-checkout-continue">
+                    <div class="venmo-checkout-close">
                       <a href="#" onClick={closeCheckout} aria-label="close">
                         {content.cancelMessage}
                       </a>

--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -30,6 +30,8 @@ export type TDSProps = {|
   content?: void | {|
     windowMessage?: string,
     continueMessage?: string,
+    cancelMessage?: string,
+    interrogativeMessage?: string,
   |},
   userType: ?$Values<typeof USER_TYPE>,
   nonce: string,

--- a/test/integration/tests/overlay/happy.jsx
+++ b/test/integration/tests/overlay/happy.jsx
@@ -120,6 +120,8 @@ describe(`paypal overlay component happy path`, () => {
     ) {
       throw new Error(`Expected overlay to be full screen`);
     }
+
+    fullScreen = false; // reset
   });
 
   it("should hide the overlay close button", () => {
@@ -282,6 +284,8 @@ describe(`venmo overlay component happy path`, () => {
     ) {
       throw new Error(`Expected overlay to be full screen`);
     }
+
+    fullScreen = false; // reset
   });
 
   it("should hide the overlay close button", () => {
@@ -297,7 +301,7 @@ describe(`venmo overlay component happy path`, () => {
     hideCloseButton = false; // reset
   });
 
-  it.skip("should be able to close the overlay using close button", () => {
+  it("should be able to close the overlay using close button", () => {
     const domNode = getOverlay().render(dom());
     addOverlayToDOM(domNode);
 

--- a/test/integration/tests/overlay/happy.jsx
+++ b/test/integration/tests/overlay/happy.jsx
@@ -4,7 +4,7 @@
 import { node, dom } from "@krakenjs/jsx-pragmatic/src";
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 
-import { Overlay } from "../../../../src/overlay";
+import { Overlay, VenmoOverlay } from "../../../../src/overlay";
 
 describe(`paypal overlay component happy path`, () => {
   const cancel = () => undefined;
@@ -156,6 +156,164 @@ describe(`paypal overlay component happy path`, () => {
 
     getOverlayContainer(domNode)
       .querySelector(".paypal-checkout-overlay")
+      .click();
+
+    if (!focussed) {
+      throw new Error(`Expected overlay to be focussed after clicking on it`);
+    }
+
+    focussed = null; // reset
+  });
+});
+
+describe(`venmo overlay component happy path`, () => {
+  const cancel = () => undefined;
+
+  let context = "popup";
+  let focussed;
+
+  const close = () => ZalgoPromise.resolve();
+  const focus = () => {
+    focussed = true;
+    return ZalgoPromise.resolve();
+  };
+  const event = {
+    on: () => ({ cancel }),
+    once: () => ({ cancel }),
+    reset: () => undefined,
+    trigger: () => ZalgoPromise.resolve(),
+    triggerOnce: () => ZalgoPromise.resolve(),
+  };
+  const frame = null;
+  const prerenderFrame = null;
+  const content = {
+    windowMessage: "window message",
+    continueMessage: "continue message",
+    cancelMessage: "cancel message",
+    interrogativeMessage: "interrogative message",
+  };
+  const autoResize = true;
+  let hideCloseButton = false;
+  const nonce = "abc123";
+  let fullScreen = false;
+
+  const getOverlay = () => (
+    <VenmoOverlay
+      context={context}
+      content={content}
+      close={close}
+      focus={focus}
+      event={event}
+      frame={frame}
+      prerenderFrame={prerenderFrame}
+      autoResize={autoResize}
+      hideCloseButton={hideCloseButton}
+      nonce={nonce}
+      fullScreen={fullScreen}
+    />
+  );
+
+  const addOverlayToDOM = (child) => {
+    // $FlowFixMe[incompatible-use]
+    document.body.appendChild(child);
+  };
+
+  const getOverlayContainer = (domNode) => {
+    return domNode.querySelector("iframe").contentWindow.document;
+  };
+
+  beforeEach(() => {
+    // $FlowFixMe[incompatible-use]
+    document.body.innerHTML = "";
+  });
+
+  it("should render the overlay component", () => {
+    const domNode = getOverlay().render(dom());
+
+    if (domNode.ownerDocument !== document) {
+      throw new Error(
+        `Expected overlay component to be rendered to current dom`
+      );
+    }
+  });
+
+  it("should render the overlay component with popup", () => {
+    context = "popup";
+
+    const domNode = getOverlay().render(dom());
+    addOverlayToDOM(domNode);
+
+    if (
+      !getOverlayContainer(domNode).querySelector(
+        ".venmo-overlay-context-popup"
+      )
+    ) {
+      throw new Error(`Expected overlay to have popup`);
+    }
+  });
+
+  it("should render the overlay component with iframe", () => {
+    context = "iframe";
+
+    const domNode = getOverlay().render(dom());
+    addOverlayToDOM(domNode);
+
+    if (
+      !getOverlayContainer(domNode).querySelector(
+        ".venmo-overlay-context-iframe"
+      )
+    ) {
+      throw new Error(`Expected overlay to have iframe`);
+    }
+
+    context = "popup"; // reset
+  });
+
+  it("should render the overlay component fullscreen", () => {
+    fullScreen = true;
+
+    const domNode = getOverlay().render(dom());
+    addOverlayToDOM(domNode);
+
+    if (
+      !getOverlayContainer(domNode).querySelector(
+        ".venmo-checkout-iframe-container-full"
+      )
+    ) {
+      throw new Error(`Expected overlay to be full screen`);
+    }
+  });
+
+  it("should hide the overlay close button", () => {
+    hideCloseButton = true;
+
+    const domNode = getOverlay().render(dom());
+    addOverlayToDOM(domNode);
+
+    if (getOverlayContainer(domNode).querySelector(".venmo-checkout-close")) {
+      throw new Error(`Expected close button to be hidden`);
+    }
+
+    hideCloseButton = false; // reset
+  });
+
+  it.skip("should be able to close the overlay using close button", () => {
+    const domNode = getOverlay().render(dom());
+    addOverlayToDOM(domNode);
+
+    getOverlayContainer(domNode).querySelector(".venmo-checkout-close").click();
+
+    if (getOverlayContainer(domNode).querySelector(".venmo-checkout-sandbox")) {
+      throw new Error(`Expected overlay to be removed after closing`);
+    }
+  });
+
+  it("should be able to focus on the overlay by clicking on it", () => {
+    const domNode = getOverlay().render(dom());
+    addOverlayToDOM(domNode);
+
+    getOverlayContainer(domNode)
+      .querySelector(".venmo-checkout-overlay")
       .click();
 
     if (!focussed) {


### PR DESCRIPTION
This PR adds a Venmo overlay component as requested in DTPPCPSDK-1254. It will be used for all Venmo button clicks, including Venmo Web use cases. The goal was to mimic the look and behavior of the BT SDK Venmo overlay in the PP SDK.

It was decided by Product that we should hard code English for now (English is currently the only language supported by Venmo), and that we should completely separate styles despite there being some duplication with the PayPal overlay.

Here's a video demonstrating switching between the PayPal and Venmo overlays, including still displaying English in the Venmo overlay after setting the browser language (i.e. `navigator.language`) to Spanish:

https://github.com/paypal/paypal-common-components/assets/20399044/727997a8-aefa-4d46-9564-3acf0faeaeaa