### PR TITLE
Tweak Venmo overlay

### DIFF
--- a/src/overlay/style.js
+++ b/src/overlay/style.js
@@ -452,7 +452,7 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
             transform: translate3d(0, 0, 0);
 
             background-color: black;
-            background-color: rgba(0, 0, 0, 0.4);
+            background-color: rgba(0, 0, 0, 0.8);
             background: radial-gradient(50% 50%, ellipse closest-corner, rgba(0,0,0,0.6) 1%, rgba(0,0,0,0.8) 100%);
 
             color: #fff;

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -252,17 +252,17 @@ export function VenmoOverlay({
       return;
     }
 
+    // Note: alerts block the event loop until they are closed.
     if (isIos()) {
       // eslint-disable-next-line no-alert
       window.alert("Please switch tabs to reactivate the Venmo window");
     } else if (isFirefox()) {
       // eslint-disable-next-line no-alert
       window.alert(
-        'Don\'t see the popup window?\n\nSelect "Window" in your toolbar to find "Log in to your Venmo account"'
+        'Don\'t see the popup window after clicking "OK"?\n\nSelect "Window" in your toolbar to find "Log in to your Venmo account"'
       );
-    } else {
-      focus();
     }
+    focus();
   }
 
   const setupAnimations = (name) => {
@@ -359,7 +359,10 @@ export function VenmoOverlay({
                   )}
                   {content.continueMessage && (
                     <div class="venmo-checkout-continue">
-                      <a onClick={focus} href="#">
+                      {/* This handler should be guarded with e.stopPropagation. 
+                          This will stop the event from bubbling up to the overlay click handler
+                          and causing unexpected behavior. */}
+                      <a onClick={focusCheckout} href="#">
                         {content.continueMessage}
                       </a>
                     </div>


### PR DESCRIPTION
### Description

The Venmo overlay is not opaque enough, so we decided to match the opacity to the PayPal overlay. Additionally, new logic was introduced to the PayPal overlay in https://github.com/paypal/paypal-common-components/pull/83 to unblock the event loop, which has been replicated for the Venmo overlay.

**Before**

![Screenshot 2023-11-15 at 10 46 25 AM](https://github.com/paypal/paypal-common-components/assets/20399044/08672adc-29c2-4d66-a343-08a43b5fb457)

**After**

![Screenshot 2023-11-15 at 10 44 46 AM](https://github.com/paypal/paypal-common-components/assets/20399044/5143103a-50c3-43ea-b97e-96d889ecf3e2)