### PR TITLE
Ensure alerts are acknowledged before focusing popup

### DIFF
--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -21,7 +21,7 @@ import {
   PayPalLogo,
   VenmoLogo,
 } from "@paypal/sdk-logos/src";
-import type { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
+import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 
 import {
   getContainerStyle,

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -50,6 +50,14 @@ export type OverlayProps = {|
   fullScreen?: boolean,
 |};
 
+function showAlert(message) {
+  return new Promise(function (resolve) {
+    // eslint-disable-next-line no-alert
+    window.alert(message);
+    resolve();
+  });
+}
+
 export function Overlay({
   context,
   close,
@@ -64,14 +72,6 @@ export function Overlay({
   fullScreen = false,
 }: OverlayProps): ElementNode {
   const uid = `paypal-overlay-${uniqueID()}`;
-
-  function showAlert(message) {
-    return new Promise(function (resolve) {
-      // eslint-disable-next-line no-alert
-      window.alert(message);
-      resolve();
-    });
-  }
 
   function closeCheckout(e) {
     e.preventDefault();
@@ -263,15 +263,16 @@ export function VenmoOverlay({
 
     // Note: alerts block the event loop until they are closed.
     if (isIos()) {
-      // eslint-disable-next-line no-alert
-      window.alert("Please switch tabs to reactivate the Venmo window");
-    } else if (isFirefox()) {
-      // eslint-disable-next-line no-alert
-      window.alert(
-        'Don\'t see the popup window after clicking "OK"?\n\nSelect "Window" in your toolbar to find "Log in to your Venmo account"'
+      showAlert("Please switch tabs to reactivate the PayPal window").then(() =>
+        focus()
       );
+    } else if (isFirefox()) {
+      showAlert(
+        'Don\'t see the popup window after clicking "OK"?\n\nSelect "Window" in your toolbar to find "Log in to your PayPal account"'
+      ).then(() => focus());
+    } else {
+      focus();
     }
-    focus();
   }
 
   const setupAnimations = (name) => {

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -263,12 +263,12 @@ export function VenmoOverlay({
 
     // Note: alerts block the event loop until they are closed.
     if (isIos()) {
-      showAlert("Please switch tabs to reactivate the PayPal window").then(() =>
+      showAlert("Please switch tabs to reactivate the Venmo window").then(() =>
         focus()
       );
     } else if (isFirefox()) {
       showAlert(
-        'Don\'t see the popup window after clicking "OK"?\n\nSelect "Window" in your toolbar to find "Log in to your PayPal account"'
+        'Don\'t see the popup window after clicking "OK"?\n\nSelect "Window" in your toolbar to find "Log in to your Venmo account"'
       ).then(() => focus());
     } else {
       focus();

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -65,6 +65,14 @@ export function Overlay({
 }: OverlayProps): ElementNode {
   const uid = `paypal-overlay-${uniqueID()}`;
 
+  function showAlert(message) {
+    return new Promise(function (resolve) {
+      // eslint-disable-next-line no-alert
+      window.alert(message);
+      resolve();
+    });
+  }
+
   function closeCheckout(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -81,15 +89,16 @@ export function Overlay({
 
     // Note: alerts block the event loop until they are closed.
     if (isIos()) {
-      // eslint-disable-next-line no-alert
-      window.alert("Please switch tabs to reactivate the PayPal window");
-    } else if (isFirefox()) {
-      // eslint-disable-next-line no-alert
-      window.alert(
-        'Don\'t see the popup window after clicking "OK"?\n\nSelect "Window" in your toolbar to find "Log in to your PayPal account"'
+      showAlert("Please switch tabs to reactivate the PayPal window").then(() =>
+        focus()
       );
+    } else if (isFirefox()) {
+      showAlert(
+        'Don\'t see the popup window after clicking "OK"?\n\nSelect "Window" in your toolbar to find "Log in to your PayPal account"'
+      ).then(() => focus());
+    } else {
+      focus();
     }
-    focus();
   }
 
   const setupAnimations = (name) => {

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -51,7 +51,7 @@ export type OverlayProps = {|
 |};
 
 function showAlert(message) {
-  return new Promise(function (resolve) {
+  return new Promise((resolve) => {
     // eslint-disable-next-line no-alert
     window.alert(message);
     resolve();

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -50,8 +50,8 @@ export type OverlayProps = {|
   fullScreen?: boolean,
 |};
 
-function showAlert(message): Promise<void> {
-  return new Promise((resolve) => {
+function showAlert(message): ZalgoPromise<void> {
+  return new ZalgoPromise((resolve) => {
     // eslint-disable-next-line no-alert
     window.alert(message);
     resolve();

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -50,7 +50,7 @@ export type OverlayProps = {|
   fullScreen?: boolean,
 |};
 
-function showAlert(message) {
+function showAlert(message): Promise<void> {
   return new Promise((resolve) => {
     // eslint-disable-next-line no-alert
     window.alert(message);


### PR DESCRIPTION
The `window.alert` function typically blocks the execution of subsequent code until the user dismisses the alert, but in some cases, it may not behave as expected. In some cases the alert will trigger AFTER the focus function is called and will then proceed to block async calls on the merchant's page after checkout.

The suggested fix is to make sure alerts are not triggered after focus (but rather before) by putting them inside a Promise and only focus after the promise is resolved. This forces the focus function to be queued in the microtask queue and to be called after alert is triggered and acknowledged.

Link to the original ticket for this: [LI-25798](https://paypal.atlassian.net/browse/LI-25798)