### PR TITLE
Fix alert blocking li 25798

### DIFF
--- a/src/overlay/style.js
+++ b/src/overlay/style.js
@@ -207,6 +207,12 @@ export function getContainerStyle({ uid }: {| uid: string |}): string {
             transform: rotate(-45deg);
         }
 
+        #${uid} .paypal-checkout-focus-warning {
+            font-size: 14px;
+            line-height: 1.35;
+            padding: 10px 0;
+        }
+
         #${uid} .paypal-checkout-iframe-container {
             display: none;
         }

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -83,7 +83,7 @@ export function Overlay({
     if (!warningElement) {
       return;
     }
-    warningElement.innerText = `Still can\'t see it? Select "Window" in your toolbar to find "Log in to your PayPal account"`;
+    warningElement.innerText = `Still can't see it? Select "Window" in your toolbar to find "Log in to your PayPal account"`;
   }
 
   function focusCheckout(e) {
@@ -268,7 +268,7 @@ export function VenmoOverlay({
     if (!warningElement) {
       return;
     }
-    warningElement.innerText = `Still can\'t see it? Select "Window" in your toolbar to find "Log in to your Venmo account"`;
+    warningElement.innerText = `Still can't see it? Select "Window" in your toolbar to find "Log in to your Venmo account"`;
   }
 
   function focusCheckout(e) {

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -96,6 +96,7 @@ export function Overlay({
 
     if (isIos()) {
       // Note: alerts block the event loop until they are closed.
+      // eslint-disable-next-line no-alert
       window.alert("Please switch tabs to reactivate the PayPal window");
     } else if (isFirefox()) {
       displayFocusWarning();
@@ -281,6 +282,7 @@ export function VenmoOverlay({
 
     if (isIos()) {
       // Note: alerts block the event loop until they are closed.
+      // eslint-disable-next-line no-alert
       window.alert("Please switch tabs to reactivate the Venmo window");
     } else if (isFirefox()) {
       displayFocusWarning();

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -21,7 +21,7 @@ import {
   PayPalLogo,
   VenmoLogo,
 } from "@paypal/sdk-logos/src";
-import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
+import { type ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 
 import {
   getContainerStyle,
@@ -50,14 +50,6 @@ export type OverlayProps = {|
   fullScreen?: boolean,
 |};
 
-function showAlert(message): ZalgoPromise<void> {
-  return new ZalgoPromise((resolve) => {
-    // eslint-disable-next-line no-alert
-    window.alert(message);
-    resolve();
-  });
-}
-
 export function Overlay({
   context,
   close,
@@ -72,6 +64,7 @@ export function Overlay({
   fullScreen = false,
 }: OverlayProps): ElementNode {
   const uid = `paypal-overlay-${uniqueID()}`;
+  const overlayIframeName = `__paypal_checkout_sandbox_${uid}__`;
 
   function closeCheckout(e) {
     e.preventDefault();
@@ -87,18 +80,26 @@ export function Overlay({
       return;
     }
 
-    // Note: alerts block the event loop until they are closed.
     if (isIos()) {
-      showAlert("Please switch tabs to reactivate the PayPal window").then(() =>
-        focus()
-      );
+      // Note: alerts block the event loop until they are closed.
+      window.alert("Please switch tabs to reactivate the PayPal window");
     } else if (isFirefox()) {
-      showAlert(
-        'Don\'t see the popup window after clicking "OK"?\n\nSelect "Window" in your toolbar to find "Log in to your PayPal account"'
-      ).then(() => focus());
-    } else {
-      focus();
+      displayFocusWarning();
     }
+    focus();
+  }
+
+  function displayFocusWarning() {
+    const overlayIframe: HTMLIFrameElement | undefined =
+      document.getElementsByName(overlayIframeName)?.[0];
+    const iframeDocument = overlayIframe?.contentWindow.document;
+    const warningElement = iframeDocument?.getElementsByClassName(
+      "paypal-checkout-focus-warning"
+    )?.[0];
+
+    if (!warningElement) return;
+
+    warningElement.innerText = `Still can\'t see it? Select "Window" in your toolbar to find "Log in to your PayPal account"`;
   }
 
   const setupAnimations = (name) => {
@@ -167,7 +168,7 @@ export function Overlay({
       <style nonce={nonce}>{getSandboxStyle({ uid })}</style>
       <iframe
         title="PayPal Checkout Overlay"
-        name={`__paypal_checkout_sandbox_${uid}__`}
+        name={overlayIframeName}
         scrolling="no"
         class={`paypal-checkout-sandbox-iframe${fullScreen ? "-full" : ""}`}
       >
@@ -198,6 +199,7 @@ export function Overlay({
                       {content.windowMessage}
                     </div>
                   )}
+                  <div class="paypal-checkout-focus-warning" />
                   {content.continueMessage && (
                     <div class="paypal-checkout-continue">
                       {/* This handler should be guarded with e.stopPropagation. 
@@ -246,6 +248,7 @@ export function VenmoOverlay({
   fullScreen = false,
 }: OverlayProps): ElementNode {
   const uid = `venmo-overlay-${uniqueID()}`;
+  const overlayIframeName = `__venmo_checkout_sandbox_${uid}__`;
 
   function closeCheckout(e) {
     e.preventDefault();
@@ -261,18 +264,26 @@ export function VenmoOverlay({
       return;
     }
 
-    // Note: alerts block the event loop until they are closed.
     if (isIos()) {
-      showAlert("Please switch tabs to reactivate the Venmo window").then(() =>
-        focus()
-      );
+      // Note: alerts block the event loop until they are closed.
+      window.alert("Please switch tabs to reactivate the Venmo window");
     } else if (isFirefox()) {
-      showAlert(
-        'Don\'t see the popup window after clicking "OK"?\n\nSelect "Window" in your toolbar to find "Log in to your Venmo account"'
-      ).then(() => focus());
-    } else {
-      focus();
+      displayFocusWarning();
     }
+    focus();
+  }
+
+  function displayFocusWarning() {
+    const overlayIframe: HTMLIFrameElement | undefined =
+      document.getElementsByName(overlayIframeName)?.[0];
+    const iframeDocument = overlayIframe?.contentWindow.document;
+    const warningElement = iframeDocument?.getElementsByClassName(
+      "paypal-checkout-focus-warning"
+    )?.[0];
+
+    if (!warningElement) return;
+
+    warningElement.innerText = `Still can\'t see it? Select "Window" in your toolbar to find "Log in to your Venmo account"`;
   }
 
   const setupAnimations = (name) => {
@@ -341,7 +352,7 @@ export function VenmoOverlay({
       <style nonce={nonce}>{getVenmoSandboxStyle({ uid })}</style>
       <iframe
         title="Venmo Checkout Overlay"
-        name={`__venmo_checkout_sandbox_${uid}__`}
+        name={overlayIframeName}
         scrolling="no"
         class={`venmo-checkout-sandbox-iframe${fullScreen ? "-full" : ""}`}
       >
@@ -362,6 +373,7 @@ export function VenmoOverlay({
                       {content.interrogativeMessage}
                     </div>
                   )}
+                  <div class="paypal-checkout-focus-warning" />
                   {content.windowMessage && (
                     <div class="venmo-checkout-message">
                       {content.windowMessage}

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -80,8 +80,9 @@ export function Overlay({
       "paypal-checkout-focus-warning"
     )?.[0];
 
-    if (!warningElement) return;
-
+    if (!warningElement) {
+      return;
+    }
     warningElement.innerText = `Still can\'t see it? Select "Window" in your toolbar to find "Log in to your PayPal account"`;
   }
 
@@ -264,8 +265,9 @@ export function VenmoOverlay({
       "paypal-checkout-focus-warning"
     )?.[0];
 
-    if (!warningElement) return;
-
+    if (!warningElement) {
+      return;
+    }
     warningElement.innerText = `Still can\'t see it? Select "Window" in your toolbar to find "Log in to your Venmo account"`;
   }
 

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -74,7 +74,7 @@ export function Overlay({
 
   function displayFocusWarning() {
     const overlayIframe: ?HTMLIFrameElement =
-      //$FlowFixMe
+      //  $FlowFixMe
       document.getElementsByName(overlayIframeName)?.[0];
     const iframeDocument = overlayIframe?.contentWindow.document;
     const warningElement = iframeDocument?.getElementsByClassName(
@@ -261,7 +261,7 @@ export function VenmoOverlay({
 
   function displayFocusWarning() {
     const overlayIframe: ?HTMLIFrameElement =
-      //$FlowFixMe
+      // $FlowFixMe
       document.getElementsByName(overlayIframeName)?.[0];
     const iframeDocument = overlayIframe?.contentWindow.document;
     const warningElement = iframeDocument?.getElementsByClassName(

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -72,6 +72,19 @@ export function Overlay({
     close();
   }
 
+  function displayFocusWarning() {
+    const overlayIframe: HTMLIFrameElement | undefined =
+      document.getElementsByName(overlayIframeName)?.[0];
+    const iframeDocument = overlayIframe?.contentWindow.document;
+    const warningElement = iframeDocument?.getElementsByClassName(
+      "paypal-checkout-focus-warning"
+    )?.[0];
+
+    if (!warningElement) return;
+
+    warningElement.innerText = `Still can\'t see it? Select "Window" in your toolbar to find "Log in to your PayPal account"`;
+  }
+
   function focusCheckout(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -87,19 +100,6 @@ export function Overlay({
       displayFocusWarning();
     }
     focus();
-  }
-
-  function displayFocusWarning() {
-    const overlayIframe: HTMLIFrameElement | undefined =
-      document.getElementsByName(overlayIframeName)?.[0];
-    const iframeDocument = overlayIframe?.contentWindow.document;
-    const warningElement = iframeDocument?.getElementsByClassName(
-      "paypal-checkout-focus-warning"
-    )?.[0];
-
-    if (!warningElement) return;
-
-    warningElement.innerText = `Still can\'t see it? Select "Window" in your toolbar to find "Log in to your PayPal account"`;
   }
 
   const setupAnimations = (name) => {
@@ -256,6 +256,19 @@ export function VenmoOverlay({
     close();
   }
 
+  function displayFocusWarning() {
+    const overlayIframe: HTMLIFrameElement | undefined =
+      document.getElementsByName(overlayIframeName)?.[0];
+    const iframeDocument = overlayIframe?.contentWindow.document;
+    const warningElement = iframeDocument?.getElementsByClassName(
+      "paypal-checkout-focus-warning"
+    )?.[0];
+
+    if (!warningElement) return;
+
+    warningElement.innerText = `Still can\'t see it? Select "Window" in your toolbar to find "Log in to your Venmo account"`;
+  }
+
   function focusCheckout(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -271,19 +284,6 @@ export function VenmoOverlay({
       displayFocusWarning();
     }
     focus();
-  }
-
-  function displayFocusWarning() {
-    const overlayIframe: HTMLIFrameElement | undefined =
-      document.getElementsByName(overlayIframeName)?.[0];
-    const iframeDocument = overlayIframe?.contentWindow.document;
-    const warningElement = iframeDocument?.getElementsByClassName(
-      "paypal-checkout-focus-warning"
-    )?.[0];
-
-    if (!warningElement) return;
-
-    warningElement.innerText = `Still can\'t see it? Select "Window" in your toolbar to find "Log in to your Venmo account"`;
   }
 
   const setupAnimations = (name) => {

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -73,7 +73,8 @@ export function Overlay({
   }
 
   function displayFocusWarning() {
-    const overlayIframe: HTMLIFrameElement | undefined =
+    const overlayIframe: ?HTMLIFrameElement =
+      //$FlowFixMe
       document.getElementsByName(overlayIframeName)?.[0];
     const iframeDocument = overlayIframe?.contentWindow.document;
     const warningElement = iframeDocument?.getElementsByClassName(
@@ -259,7 +260,8 @@ export function VenmoOverlay({
   }
 
   function displayFocusWarning() {
-    const overlayIframe: HTMLIFrameElement | undefined =
+    const overlayIframe: ?HTMLIFrameElement =
+      //$FlowFixMe
       document.getElementsByName(overlayIframeName)?.[0];
     const iframeDocument = overlayIframe?.contentWindow.document;
     const warningElement = iframeDocument?.getElementsByClassName(


### PR DESCRIPTION
**The situation**
We offer an overlay under the PayPal popup that puts users back into the happy path (we focus the checkout popup back). We have a special case for Firefox because it sometimes does not focus the popup correctly (whether because popups are blocked or because it simply focus does not work). We warn them of this by setting a window.alert with instructions for when popup does not come back into focus.

**The problem**
In the current implementation for overlay in Firefox, users can’t focus the popup back (from the overlay) until they acknowledge the alert, yet nothing prevents them from manually focusing the popup by:
Rearranging their windows and clicking the popup window manually.
Open the window using the Firefox toolbar.
Some other way of changing focus back.
When this happens, the user does not necessarily have to acknowledge the alert and that introduces the problem of the alert hanging on the merchant page and thus blocking any async calls made by checkout. This leads to infinite loading because onApprove is never able to fire.

**Proposed solution**
It seems like the Firefox alert can cause problems regardless of how we handle the behavior from the overlay.
The proposed solution to this is to display a message directly on the overlay when the user tries to go back to the happy path.

There are two possible outcomes:
1. The popup focuses back, the user never sees the message and proceeds with checkout as expected.
2. The popup does not focus and the user gets a message on the overlay (below the click to continue maybe?)
In either case, we avoid blocking the main page with an alert that might interfere with the checkout flow’s async calls and we also manage to instruct the user on next steps when focus fails.

**Demo of the fix**

Before focus:
![image (1)](https://github.com/paypal/paypal-common-components/assets/101415858/44d84733-1a26-4da0-998d-bf6c8254b6da)

After focus:
![image (2)](https://github.com/paypal/paypal-common-components/assets/101415858/25d91559-db42-4229-add6-ba1b995d257b)
