### PR TITLE
Add and Use PayPal Open Font

### DIFF
--- a/src/overlay/style.js
+++ b/src/overlay/style.js
@@ -113,7 +113,7 @@ export function getContainerStyle({ uid }: {| uid: string |}): string {
         }
 
         #${uid} .paypal-checkout-modal {
-            font-family: "HelveticaNeue", "HelveticaNeue-Light", "Helvetica Neue Light", helvetica, arial, sans-serif;
+            font-family: "PayPalOpen-Regular", "Helvetica Neue", Arial, sans-serif;
             font-size: 14px;
             text-align: center;
 
@@ -490,7 +490,7 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
         }
 
         #${uid} .venmo-checkout-modal .venmo-interrogative-message {
-            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            font-family: "PayPalOpen-Regular", "Helvetica Neue", Arial, sans-serif;
             font-style: normal;
             font-size: 24px;
             line-height: 32px;
@@ -520,7 +520,7 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
         }
 
         #${uid} .venmo-checkout-modal .venmo-checkout-message {
-            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            font-family: "PayPalOpen-Regular", "Helvetica Neue", Arial, sans-serif;
             font-style: normal;
             font-weight: 400;
             font-size: 16px;
@@ -538,7 +538,7 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
             background: #0074DE;
             border-radius: 24px;
             border: none;
-            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            font-family: "PayPalOpen-Regular", "Helvetica Neue", Arial, sans-serif;
             font-style: normal;
             font-weight: 700;
             font-size: 18px;
@@ -551,7 +551,7 @@ export function getVenmoContainerStyle({ uid }: {| uid: string |}): string {
         }
 
         #${uid} .venmo-checkout-close {
-            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            font-family: "PayPalOpen-Regular", "Helvetica Neue", Arial, sans-serif;
             font-style: normal;
             font-weight: 700;
             font-size: 18px;


### PR DESCRIPTION
### Why is this change required?
<!--
- Motivation and Summary
- JIRA Ticket, Rally Story, etc
- Links to Product Requirements and/or Design Documents
- Links to approved specification
-->
We are redesigning the PayPal button and updating the font as a part of this redesign.
https://paypal.atlassian.net/browse/DTPPCPSDK-1682

### Additional PRs with CSS Changes
[paypal-checkout-components](https://github.com/paypal/paypal-checkout-components/pull/2315)
[smartcomponentnodeweb](https://github.paypal.com/Checkout-R/smartcomponentnodeweb/pull/553)

### View Visual Changes
1. Clone [button-redesign-storybook](https://github.paypal.com/Core-SDK/button-redesign-storybook)
2. Follow Quick Setup instructions for button-redesign-repo
3. Run Storybook: `npm run storybook`
4. Checkout `feature/redesign-fronts` branch for `smartcomponentnodeweb`
5. Checkout `feature/redesign-fronts` branch for `paypal-checkout-components`
6. Checkout `feature/redesign-fronts` branch for `paypal-common-components`
7. Run JS SDK locally
8. View changes in Storybook!

### Type of change
<!--
Check all that best describes your change.
-->
- [ ] Breaking change (backward incompatible change). **Provide references to customer impact and communication.**
- [x] New feature (backward compatible change that adds new capability).
- [ ] Bug fix.
- [ ] Refactor (no functional change)

### Impact of change
<!--
Describe the change **before** and **after** your change. e.g. API samples, error samples, performance numbers, etc
-->
PayPal Open font should be used everywhere in the SDK