### PR TITLE
Add iPadOs device check to overlay continue button

### DIFF
--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -4,6 +4,7 @@
 
 import {
   isIos,
+  isIpadOs,
   isFirefox,
   animate,
   noop,
@@ -95,7 +96,7 @@ export function Overlay({
       return;
     }
 
-    if (isIos()) {
+    if (isIos() || isIpadOs()) {
       // Note: alerts block the event loop until they are closed.
       // eslint-disable-next-line no-alert
       window.alert("Please switch tabs to reactivate the PayPal window");


### PR DESCRIPTION
### Description

Our overlay currently will check for iOS when the continue message is clicked. If the device is an iOS device, it will display an alert and prompt the user to switch to the tab manually to reactivate the PayPal window. 

However, Safari on iOS13 and up on an iPad device will return a user agent that looks like a MacOS desktop user agent and this alert is not displayed.

The proposed solution will cover this edge case and properly display the alert message.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

Jira Ticket - LI-30263

### Screenshots (if applicable)

![Simulator Screenshot - iPad Air (5th generation) - 2024-02-13 at 11 19 06](https://github.com/paypal/paypal-common-components/assets/38122192/d9beac5f-64d2-4299-99f3-f608c67dacb6)


### Dependent Changes (if applicable)

[Related PR from krakenjs/belter](https://github.com/krakenjs/belter/pull/114)

### Groups who should review (if applicable)


❤️ Thank you!