### PR TITLE
Fix 3DS tests

### DIFF
--- a/test/paypal.js
+++ b/test/paypal.js
@@ -1,10 +1,13 @@
 /* @flow */
 
-import { setupSDK, insertMockSDKScript } from "@paypal/sdk-client/src";
+import { setupSDK } from "@paypal/sdk-client/src";
 
 import * as paypalCheckout from "../src/interface"; // eslint-disable-line import/no-namespace
 
-insertMockSDKScript();
+document.currentScript?.setAttribute(
+  "src",
+  "test.paypal.com/sdk/js?client-id=abcxyz123"
+);
 
 window.mockDomain = "mock://www.paypal.com";
 


### PR DESCRIPTION
### Description
This PR fixes an issue that was introduced with the latest versions of `@paypal/sdk-client`.

### Why are we making these changes?
CI is failing for new PRs to `paypal-common-components`.

### Reproduction Steps
Run `npm run karma` with `v4.0.181` or later of `@paypal/sdk-client`.

### Screenshots
Works with `v4.0.180`:
<img width="1114" alt="Screenshot 2024-02-26 at 3 13 48 PM" src="https://github.com/paypal/paypal-common-components/assets/20399044/b8d5c498-fe3b-4870-b853-012da29b9536">

Breaks with `v4.0.181` or later:
<img width="1139" alt="Screenshot 2024-02-26 at 3 16 00 PM" src="https://github.com/paypal/paypal-common-components/assets/20399044/d7eb35f2-f080-4713-a15f-1ba263fd9090">

### Dependent Changes
Unblocking [this](https://github.com/paypal/paypal-common-components/pull/91) PR for @mchoun.

### Attribution
@jshawl figured this out first [here](https://github.com/paypal/paypal-checkout-components/pull/2338). 🙏 