### PR TITLE
fix overlay rtl direction

### DIFF
--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -178,6 +178,7 @@ export function Overlay({
         <html>
           <body>
             <div
+              dir="auto"
               id={uid}
               onClick={focusCheckout}
               class={`paypal-overlay-context-${context} paypal-checkout-overlay`}

--- a/src/overlay/template.jsx
+++ b/src/overlay/template.jsx
@@ -194,7 +194,7 @@ export function Overlay({
               )}
               {!fullScreen && (
                 <div class="paypal-checkout-modal">
-                  <div class="paypal-checkout-logo">
+                  <div class="paypal-checkout-logo" dir="ltr">
                     <PPLogo logoColor={LOGO_COLOR.WHITE} />
                     <PayPalLogo logoColor={LOGO_COLOR.WHITE} />
                   </div>


### PR DESCRIPTION
This PR fixes an issue where RTL languages are not being displayed in the correct direction.

**Before**:

<img width="445" alt="Screenshot 2024-02-28 at 12 10 53" src="https://github.com/paypal/paypal-common-components/assets/3824954/51c01e12-f931-4fa3-b3be-1a4ed3f14333">

**After**:
<img width="436" alt="Screenshot 2024-02-28 at 12 09 00" src="https://github.com/paypal/paypal-common-components/assets/3824954/5e443aa3-9b7f-43d1-ac9f-c608a4eadfc4">
