### PR TITLE
handle 3DS success = false scenario for CardFields

### DIFF
--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -115,9 +115,17 @@ export function getThreeDomainSecureComponent(): TDSComponent {
         onSuccess: {
           type: "function",
           alias: "onContingencyResult",
-          decorate: ({ value, onError }) => {
+          decorate: ({ props, value, onError }) => {
             return (err, result) => {
-              if (err) {
+              const isCardFieldFlow = props.userType === "UNBRANDED_GUEST";
+
+              // HostedFields ONLY rejects when the err object is not null. The below implementation ensures that CardFields follows the same pattern.
+
+              const hasError = isCardFieldFlow
+                ? err
+                : err || result?.success === false;
+
+              if (hasError) {
                 return onError(err);
               }
 

--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -118,7 +118,9 @@ export function getThreeDomainSecureComponent(): TDSComponent {
           decorate: ({ props, value, onError }) => {
             return (err, result) => {
               const isCardFieldFlow = props?.userType === "UNBRANDED_GUEST";
+              // eslint-disable-next-line no-console
               console.log("Seb userType", { userType: props?.userType });
+              // eslint-disable-next-line no-console
               console.log("Seb cardFieldFlow", { isCardFieldFlow });
               // HostedFields ONLY rejects when the err object is not null. The below implementation ensures that CardFields follows the same pattern.
 
@@ -126,8 +128,11 @@ export function getThreeDomainSecureComponent(): TDSComponent {
                 ? err
                 : // $FlowFixMe[incompatible-use]
                   err || result?.success === false;
+              // eslint-disable-next-line no-console
               console.log("Seb err", { err });
+              // eslint-disable-next-line no-console
               console.log("Seb result", { result });
+              // eslint-disable-next-line no-console
               console.log("Seb hasError", { hasError });
               if (hasError) {
                 return onError(err);

--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -117,7 +117,7 @@ export function getThreeDomainSecureComponent(): TDSComponent {
           alias: "onContingencyResult",
           decorate: ({ props, value, onError }) => {
             return (err, result) => {
-              const isCardFieldFlow = props.userType === "UNBRANDED_GUEST";
+              const isCardFieldFlow = props?.userType === "UNBRANDED_GUEST";
 
               // HostedFields ONLY rejects when the err object is not null. The below implementation ensures that CardFields follows the same pattern.
 

--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -117,7 +117,7 @@ export function getThreeDomainSecureComponent(): TDSComponent {
           alias: "onContingencyResult",
           decorate: ({ value, onError }) => {
             return (err, result) => {
-              if (err || (result && !result.success)) {
+              if (err) {
                 return onError(err);
               }
 

--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -118,14 +118,17 @@ export function getThreeDomainSecureComponent(): TDSComponent {
           decorate: ({ props, value, onError }) => {
             return (err, result) => {
               const isCardFieldFlow = props?.userType === "UNBRANDED_GUEST";
-
+              console.log("Seb userType", { userType: props?.userType });
+              console.log("Seb cardFieldFlow", { isCardFieldFlow });
               // HostedFields ONLY rejects when the err object is not null. The below implementation ensures that CardFields follows the same pattern.
 
               const hasError = isCardFieldFlow
                 ? err
                 : // $FlowFixMe[incompatible-use]
                   err || result?.success === false;
-
+              console.log("Seb err", { err });
+              console.log("Seb result", { result });
+              console.log("Seb hasError", { hasError });
               if (hasError) {
                 return onError(err);
               }

--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -123,7 +123,8 @@ export function getThreeDomainSecureComponent(): TDSComponent {
 
               const hasError = isCardFieldFlow
                 ? err
-                : err || result?.success === false;
+                : // $FlowFixMe[incompatible-use]
+                  err || result?.success === false;
 
               if (hasError) {
                 return onError(err);

--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -118,22 +118,14 @@ export function getThreeDomainSecureComponent(): TDSComponent {
           decorate: ({ props, value, onError }) => {
             return (err, result) => {
               const isCardFieldFlow = props?.userType === "UNBRANDED_GUEST";
-              // eslint-disable-next-line no-console
-              console.log("Seb userType", { userType: props?.userType });
-              // eslint-disable-next-line no-console
-              console.log("Seb cardFieldFlow", { isCardFieldFlow });
+
               // HostedFields ONLY rejects when the err object is not null. The below implementation ensures that CardFields follows the same pattern.
 
               const hasError = isCardFieldFlow
-                ? err
+                ? Boolean(err)
                 : // $FlowFixMe[incompatible-use]
-                  err || result?.success === false;
-              // eslint-disable-next-line no-console
-              console.log("Seb err", { err });
-              // eslint-disable-next-line no-console
-              console.log("Seb result", { result });
-              // eslint-disable-next-line no-console
-              console.log("Seb hasError", { hasError });
+                  Boolean(err) || result?.success === false;
+
               if (hasError) {
                 return onError(err);
               }


### PR DESCRIPTION
## The situation
Currently, the 3DS component will check the response from helios to see if the error object is null or if the `result.success` property is false. If either of these scenarios are true, then the onError callback will be trigger. Otherwise, the results will be returned to the onSuccess callback. 

## The problem
This logic does not align with the 3DS response logic for the HostedFields. In the HostedFields, the response data will still be returned if `result.success` property is false. In order to bring CardFields to parity with the HostedFields, the logic must only trigger the onError callback if the error object is not null.  

Since this component is shared between different payment flows, this logic must only be in place if the payment flow is through the CardFields. 

## Proposed solution
The inline guest checkout (BCDC) currently passes `userType` as `BRANDED_GUEST`. The proposed solution is to pass userType as 'UNBRANDED_GUEST' from the CardFields component to the 3DS component which will modify the error checking logic. 

Screenshots

isCardFieldFlow is true since UNBRANDED_GUEST was passed. `success = true` and no error was thrown.
![image](https://github.com/paypal/paypal-common-components/assets/38122192/3f77d456-9f82-4d04-9737-c6a45ecc609b)


isCardFieldFlow is true since UNBRANDED_GUEST was passed. `success = false` and no error was thrown.
![image](https://github.com/paypal/paypal-common-components/assets/38122192/0efc6fbe-d8f7-4e96-9597-2b06fa7404a0)

isCardFieldFlow is false since UNBRANDED_GUEST was NOT passed. `success = false` and error was thrown.
![image](https://github.com/paypal/paypal-common-components/assets/38122192/e7f22452-382f-444a-97fb-e96b959afbfe)


## Related PRs and Links
`scnw` - #672
JIRA ticket - DTPPCPSDK-2207

