### PR TITLE
(fix) add eslint-config-grumbler to resolve plugin install issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "@krakenjs/grumbler-scripts": "^8.0.4",
+    "@krakenjs/eslint-config-grumbler": "8.1.3",
     "@krakenjs/sync-browser-mocks": "^3.0.0",
     "babel-core": "^7.0.0-bridge.0",
     "conventional-changelog-cli": "^2.0.11",


### PR DESCRIPTION
Fixes issue installing a few `eslint-plugin-*` packages provided by `@krakenjs/eslint-config-grumbler` via `@krakenjs/grumbler-scripts`, where npm is no longer flattening these to `node_modules/eslint-plugin-*`. eslint then cannot find the plugin. See [here](https://github.com/paypal/paypal-common-components/actions/runs/8899789617/job/24439909704#step:6:52).

I did observe that removing `mocketeer` as a devDependency appears to also resolve this, but this package is used in `checkout-components`, which is experiencing the same issue.

Possible alternatives:
- specify all `eslint-plugin-*` packages from `grumbler-scripts`
- determine dependency causing this and use npm overrides to pin version
- remove `mocketeer` as dependency
- use of lockfile to prevent/identify unexpected graph changes due to transitive dependency updates (might not solve the underlying issue, but would prevent the unexpected change).