### PR TITLE
Update syntax for webpack arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "clean": "rimraf dist coverage",
     "reinstall": "rimraf flow-typed && rimraf node_modules && npm install && flow-typed install",
     "debug": "cross-env NODE_ENV=debug",
-    "webpack": "babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/webpack --progress",
+    "webpack": "babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/webpack -- --progress",
     "eslint-find-rules": "eslint-find-rules --current .eslintrc.js --unused --plugin",
     "prepare": "husky install"
   },


### PR DESCRIPTION
This PR is to fix a CI issue with babel-node and webpack. 

Babel-node updated their syntax so that a `--` needs to be passed to signify the following arguments are for the script and not babel-node. 

![image](https://github.com/paypal/paypal-common-components/assets/38122192/03fbf326-540e-4674-8568-5bd9e7b0985e)
