### PR TITLE
add babel-plugin-transform-es2015-modules-commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,11 @@
   "license": "Apache-2.0",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "@krakenjs/grumbler-scripts": "^8.0.4",
     "@krakenjs/eslint-config-grumbler": "8.1.3",
+    "@krakenjs/grumbler-scripts": "^8.0.4",
     "@krakenjs/sync-browser-mocks": "^3.0.0",
     "babel-core": "^7.0.0-bridge.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "conventional-changelog-cli": "^2.0.11",
     "cross-env": "^7.0.3",
     "flow-bin": "0.135.0",
@@ -78,14 +79,14 @@
     "serve": "^10.1.2"
   },
   "dependencies": {
-    "@paypal/sdk-client": "^4.0.166",
-    "@paypal/sdk-constants": "^1.0.128",
-    "@paypal/sdk-logos": "^2.2.12",
     "@krakenjs/belter": "^2.0.0",
     "@krakenjs/jsx-pragmatic": "^3.0.0",
     "@krakenjs/post-robot": "^11.0.0",
     "@krakenjs/zalgo-promise": "^2.0.0",
-    "@krakenjs/zoid": "^10.0.0"
+    "@krakenjs/zoid": "^10.0.0",
+    "@paypal/sdk-client": "^4.0.166",
+    "@paypal/sdk-constants": "^1.0.128",
+    "@paypal/sdk-logos": "^2.2.12"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"


### PR DESCRIPTION
The github actions is failing due to missing dependency. Add `babel-plugin-transform-es2015-modules-commonjs` to address the issue 