### PR TITLE
fix: add destroy export to common component to fix double-load crash

### DIFF
--- a/src/interface.js
+++ b/src/interface.js
@@ -3,6 +3,7 @@
 import { isPayPalDomain } from "@paypal/sdk-client/src";
 // eslint-disable-next-line import/no-namespace
 import * as postRobotModule from "@krakenjs/post-robot/src";
+import { destroy as zoidDestroy } from "@krakenjs/zoid/src";
 
 import {
   getThreeDomainSecureComponent,
@@ -35,3 +36,7 @@ export const Captcha: LazyProtectedExport<CaptchaComponent> = {
 export const postRobot: LazyProtectedExport<typeof postRobotModule> = {
   __get__: () => protectedExport(postRobotModule),
 };
+
+export function destroy(err?: mixed) {
+  zoidDestroy(err);
+}

--- a/test/integration/tests/destroy/happy.js
+++ b/test/integration/tests/destroy/happy.js
@@ -1,0 +1,42 @@
+/* @flow */
+/* eslint max-lines: 0 */
+
+import { create } from "@krakenjs/zoid/src";
+
+import { destroy } from "../../../../src/interface";
+
+describe("destroy export", () => {
+  it("should export a destroy function", () => {
+    if (typeof destroy !== "function") {
+      throw new TypeError("Expected destroy to be a function");
+    }
+  });
+
+  it("should not throw when called multiple times", () => {
+    destroy();
+    destroy();
+  });
+
+  it("should accept an error argument", () => {
+    destroy(new Error("test destroy"));
+  });
+
+  it("should clean up zoid listeners so a component with the same tag can be re-created after destroy", () => {
+    const tag = "three-domain-secure-double-load-test";
+    const url = () => "about:blank";
+
+    create({
+      tag,
+      url,
+      attributes: { iframe: { scrolling: "no" } },
+    });
+
+    destroy();
+
+    create({
+      tag,
+      url,
+      attributes: { iframe: { scrolling: "no" } },
+    });
+  });
+});

--- a/test/integration/tests/destroy/index.js
+++ b/test/integration/tests/destroy/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+import "./happy";

--- a/test/integration/tests/index.js
+++ b/test/integration/tests/index.js
@@ -4,3 +4,4 @@ import "./three-domain-secure";
 import "./spinner-page";
 import "./overlay";
 import "./post-robot";
+import "./destroy";


### PR DESCRIPTION
## Summary

Fixes the `Bootstrap Error for common: Request listener already exists for zoid_allow_delegate_three_domain_secure` crash that occurs when the PayPal SDK script loads twice on the same page.

**Jira:** https://paypal.atlassian.net/browse/DTMOBILE-3418

## Problem

When any SDK bundle containing the `common` component loads twice on the same page, `__internal_destroy__()` runs teardown but skips `common` because it has no `destroy` export. The zoid `ThreeDomainSecure` component's post-robot listeners (`zoid_allow_delegate_three_domain_secure`) survive teardown. On the second load, post-robot's uniqueness check throws because the listener is already registered.

## Root Cause

- The SDK bootstrap loop checks `s.destroy` on each component's exports and pushes it into a cleanup array
- `common` had no `destroy` export, so nothing was registered for cleanup
- Zoid's `destroy()` (not `destroyAll()`) is required because it calls `cleanZoid.all()` which cancels the `zoid_allow_delegate_*` and `zoid_delegate_*` post-robot listeners registered at component definition time
- `destroyAll()` only cleans component instances (`cleanInstances`), not definition-time listeners

## Changes

- **`src/interface.js`**: Added `import { destroy as zoidDestroy } from "@krakenjs/zoid/src"` and `export function destroy(err) { zoidDestroy(err); }` — 2 lines added
- **`test/integration/tests/destroy/`**: Added 4 test cases including a double-load simulation that reproduces the exact production error when the fix is removed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

### Automated
- All 28 tests pass (4 new + 24 existing)
- Key test: creates a zoid component → calls `destroy()` → creates same component again. Without fix, throws `Request listener already exists`; with fix, succeeds silently

### Manual
See reproduction steps in [DTMOBILE-3418](https://paypal.atlassian.net/browse/DTMOBILE-3418)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] You have used AI for reviewing your PR
- [x] You have used AI for rating your PR in the PR description